### PR TITLE
fix: use npm_and_yarn for package-ecosystem check

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -26,7 +26,7 @@ jobs:
         if: >-
           (
             steps.metadata.outputs.package-ecosystem == 'github-actions' ||
-            steps.metadata.outputs.package-ecosystem == 'npm'
+            steps.metadata.outputs.package-ecosystem == 'npm_and_yarn'
           ) &&
           (
             steps.metadata.outputs.update-type == 'version-update:semver-patch' ||


### PR DESCRIPTION
The `dependabot/fetch-metadata` action outputs `npm_and_yarn` for the npm ecosystem, not `npm`. This caused the auto-merge step to be skipped for all npm dependabot PRs because the condition `package-ecosystem == 'npm'` never matched.