### PR TITLE
fix: use dependabot/fetch-metadata@v2

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-commit-verification: true


### PR DESCRIPTION
v3 floating tag doesn't exist - only v3.0.0 point release. Using v2 which is the latest floating tag.