### PR TITLE
chore: stagger dependabot and automerge schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: "20:00"
-      timezone: Europe/Berlin
+      time: "21:35"
     open-pull-requests-limit: 3
     labels:
       - dependencies
@@ -30,8 +29,7 @@ updates:
     directory: /
     schedule:
       interval: daily
-      time: "20:00"
-      timezone: Europe/Berlin
+      time: "21:35"
     open-pull-requests-limit: 2
     labels:
       - dependencies

--- a/.github/workflows/dependabot-automerge-cron.yml
+++ b/.github/workflows/dependabot-automerge-cron.yml
@@ -2,8 +2,8 @@ name: Dependabot Auto-merge (Cron)
 
 on:
   schedule:
-    # Run daily at 20:00 UTC (same time as dependabot)
-    - cron: '0 20 * * *'
+    # Run every 8 hours, staggered to avoid burst
+    - cron: '20 0,8,16 * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -15,6 +15,6 @@ jobs:
   check-aged-prs:
     runs-on: ubuntu-latest
     steps:
-      - uses: cmiic/dependabot-automation/cron@a221277d51fb80ee2a6ba76df53eb302706d2e3f # v1.1.0
+      - uses: cmiic/dependabot-automation/cron@5ed389108eab8ee3ec9a1ce78f91405fcd13f166 # v1.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,6 +16,6 @@ jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - uses: cmiic/dependabot-automation/merge@a221277d51fb80ee2a6ba76df53eb302706d2e3f # v1.1.0
+      - uses: cmiic/dependabot-automation/merge@5ed389108eab8ee3ec9a1ce78f91405fcd13f166 # v1.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

- Update automerge-cron to run every 8 hours (0:00, 8:00, 16:00 UTC)
- Stagger cron start times across repos (5-min intervals) to avoid burst
- Bump dependabot-automation to v1.4.0
- Remove timezone from dependabot.yml (use UTC)
- Stagger dependabot times around 21:00 UTC

## Why

The automerge cron was running at the same time as dependabot, creating a race condition. Running every 8 hours with staggered times ensures PRs are processed after CI completes.